### PR TITLE
Fix 'make doc' issue on systems with node & nodejs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ JS_TESTER = $(NODE_PATH)/vows/bin/vows
 DOC_DIR = doc
 BUILD_DIR = build
 DOC_LIST = `ls $(DOC_DIR)/md/`
-JS_ENGINE ?= `which node nodejs`
+JS_ENGINE ?= $(shell which node nodejs | grep -Po -m 1 "(.+?)$$") 
 
 all: clean core doc
 


### PR DESCRIPTION
On systems with node installed as both 'node' and 'nodejs', 'make'
will evaluate 'which node nodejs' to include both the path to 'node'
and the path to 'nodejs', ultimatley psasing 'nodejs' as the first
argument to 'node' and throwing an error.

In order to fix this, and make 'make doc' run on systems with node
aliased to both 'node' and 'nodejs', I just added a 'grep' to select
the first of 'node' and 'nodejs' if both are defined.

Tested on Ubuntu 13.10 with GNU Make 3.81, GNU bash 4.2.45(1)-release
and Node.js v0.10.26.
