### PR TITLE
Add calculation of arbitrary empirical quantiles

### DIFF
--- a/doc/md/vector.md
+++ b/doc/md/vector.md
@@ -633,6 +633,19 @@ If callback is passed then will pass result as first argument.
         // result === [25,50,75]
     });
 
+### quantiles()
+
+**quantiles( dataArray, quantilesArray, [alphap, [betap]] )**
+
+Like quartiles, but calculate and return arbitrary quantiles of a vector
+or matrix (column-by-column).
+
+    jStat.quantiles([1, 2, 3, 4, 5, 6], [0.25, 0.5, 0.75]) === [1.9375, 3.5, 5.0625]
+
+Optional parameters alphap and betap govern the quantile estimation method.
+For more details see the Wikipedia page on quantiles or scipy.stats.mstats.mquantiles
+documentation.
+
 ### covariance()
 
 **covariance( array, array )**

--- a/src/vector.js
+++ b/src/vector.js
@@ -202,7 +202,8 @@ jStat.extend({
 		];
 	},
 
-	// arbitrary quantiles of an array
+	// Arbitary quantiles of an array. Direct port of the scipy.stats
+	// implementation by Pierre GF Gerard-Marchant.
 	quantiles : function(arr, quantilesArray, alphap, betap) {
 
 	    if (typeof(alphap)==='undefined') {
@@ -212,20 +213,24 @@ jStat.extend({
 		var betap = 3/8.0;
 	    };
 
-	    var sortedQuantiles = quantilesArray.slice().sort(ascNum);
 	    var n = arr.length;
 	    var sortedArray = arr.slice().sort(ascNum);
 
 	    var quantileValues = [quantilesArray.length];
+
+	    var clip = function(arg, min, max) {
+		return Math.max(min, Math.min(arg, max));
+	    };
 	    
 	    for (var i=0; i < quantilesArray.length; i++) {
-		var quantile = quantilesArray[i];
+		var p = quantilesArray[i];
 
-		var m = alphap + quantile*(1.0-alphap-betap);
-		var j = Math.max(1, Math.min(n-1, Math.floor(n*quantile + m)));
-		var g = n*quantile + m - j;
-		
-		quantileValues[i] = (1-g)*sortedArray[j-1] + g*sortedArray[j];
+		var m = alphap + p*(1.0-alphap-betap);
+		var aleph = n*p + m;
+		var k = Math.floor(clip(aleph, 1, n-1));
+		var gamma = clip(aleph - k, 0, 1);
+
+		quantileValues[i] = (1.0 - gamma)*sortedArray[k-1] + gamma*sortedArray[k];
 	    };
 	    return quantileValues;
 	},

--- a/test/distribution-test.js
+++ b/test/distribution-test.js
@@ -2,7 +2,7 @@ var vows = require('vows'),
 assert = require('assert');
 suite = vows.describe('jStat.distribution');
 
-require('./env.js')
+require('./env.js');
 
 suite.addBatch({
 	'beta pdf': {
@@ -10,24 +10,6 @@ suite.addBatch({
 			return jStat;
 		},
 		'check pdf calculation' : function(jStat) {
-			var assertAlmostEqual = function (x, y, tol) {
-				if (x == y) {
-					// This handles positive
-					// and negative infinity
-					return true;
-				};
-				var diff = Math.abs(x-y);
-
-				if (isNaN(diff)) {
-					assert(false, "Number difference is NaN.");
-				}
-
-				if (diff > tol) {
-					assert(false, "Number difference greater than tolerance");
-				};
-
-				return true;
-			};
 
 			// Non-log form of the Beta pdf
 			var pdf = function (x, alpha, beta) {

--- a/test/env.js
+++ b/test/env.js
@@ -1,1 +1,20 @@
 jStat = require('../dist/jstat.js').jStat;
+
+assertAlmostEqual = function (x, y, tol) {
+    if (x == y) {
+	// This handles positive
+	// and negative infinity
+	return true;
+    };
+    var diff = Math.abs(x-y);
+    
+    if (isNaN(diff)) {
+	assert(false, "Number difference is NaN.");
+    }
+    
+    if (diff > tol) {
+	assert(false, "Number difference greater than tolerance");
+    };
+    
+    return true;
+};

--- a/test/vector/quantiles-test.js
+++ b/test/vector/quantiles-test.js
@@ -1,8 +1,10 @@
 var vows = require('vows'),
-	assert = require('assert')
+	assert = require('assert');
 	suite = vows.describe('jStat.quantiles');
 
 require('../env.js');
+
+var tol = 0.0000001;
 
 suite.addBatch({
 	'quantiles' : {
@@ -21,6 +23,35 @@ suite.addBatch({
 		'quantiles matrix cols' : function(jStat) {
 			assert.deepEqual(jStat([[1,2],[3,4],[5,6]]).quantiles([0.25, 0.5, 0.75]),
 					 [[1.375, 3, 4.625], [2.375, 4, 5.625]]);
+		},
+	        'quantiles normal dist' : function(jStat) {
+		    var arr = [-2.57313203,  9.84802638,  6.13625057,  8.41780777,  1.06749265,    
+			       2.1530631 ,  4.46082094,  8.26291053, -9.28064583,  0.13434825];
+
+                    var quantiles = [0.1, 0.3, 0.5, 0.8];
+
+		    var results = jStat(arr).quantiles(quantiles);
+		    var expected = [-6.59764031,  0.55426323,  3.30694202,  8.35197644];
+
+		    for (var i=0; i < quantiles.length; i++) {
+			assertAlmostEqual(results[i], expected[i], tol);
+		    }
+		},
+	        'quantiles gamma dist' : function(jStat) {
+		    var arr = [6.20504472,   7.18983495,   6.29331634,   7.72493799,
+			       6.44628893,   7.73877221,   8.26542627,   7.00870595,
+			       6.72238426,   7.09363385,   6.60325838,   5.90180641,
+			       5.79957376,  13.07687722,   6.65942804,   6.75392592,
+			       6.41813748,   7.97086739,   9.36773336];
+
+                    var quantiles = [0.83, 0.1, 0.3, 0.5, 0.8];
+
+		    var results = jStat(arr).quantiles(quantiles, 0.4, 0.4);
+		    var expected = [8.06983917, 5.99884267, 6.47140404, 6.75392592, 7.91516455];
+
+		    for (var i=0; i < quantiles.length; i++) {
+			assertAlmostEqual(results[i], expected[i], tol);
+		    }
 		}
 	},
 	'fn.quantiles vector' : {


### PR DESCRIPTION
For those users who are not satisfied by the already present `quartiles` function.

I did not make `quartiles` use the new `quantiles` function internally: this is because `quantiles` cannot reproduce the estimation method used by `quartiles` at the moment, and so all existing tests would break. Happy to change the tests though if that's what we want!
