### PR TITLE
Test Illustrating Issues with NaNs from Hypergeometric PDF

### DIFF
--- a/test/distribution-test.js
+++ b/test/distribution-test.js
@@ -66,6 +66,8 @@ suite.addBatch({
                     2290
                   ]; 
       // What was the probability of exactly this many 1s?
+      // Obtained from the calculator at 
+      // <http://www.geneprof.org/GeneProf/tools/hypergeometric.jsp>
       var answers = [
                       0.000017532028090435493,
                       0.0007404996809672229


### PR DESCRIPTION
The hypergeometric distribution PDF will sometimes return NaN when the population and sample sizes are large (in the thousands). I have added a test to illustrate this issue, which duly fails. I do not know how the test can be induced to pass, beyond the vague admonition to "apply better numerical methods" in the calculation of the PDF.
