### PR TITLE
Added install script to recreate dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "vows" : "0.7.x"
   },
   "scripts" : {
-    "test" : "./node_modules/vows/bin/vows --spec --isolate"
+    "test" : "./node_modules/vows/bin/vows --spec --isolate",
+    "install": "make jstat"
   }
 }


### PR DESCRIPTION
On some versions of npm/node dist folder is deleted (best guess make clean is run) and package is unusable. This PR forces regeneration of dist files upon _npm install_. 
