### PR TITLE
Fix #101, Triangular Distribution returning NaN

### DIFF
--- a/src/distribution.js
+++ b/src/distribution.js
@@ -897,13 +897,27 @@ jStat.extend(jStat.poisson, {
 // extend triangular function with static methods
 jStat.extend(jStat.triangular, {
   pdf: function pdf(x, a, b, c) {
-    return (b <= a || c < a || c > b)
-      ? undefined
-      : (x < a || x > b)
-        ? 0
-        : (x <= c)
-          ? (2 * (x - a)) / ((b - a) * (c - a))
-          : (2 * (b - x)) / ((b - a) * (b - c));
+    if (b <= a || c < a || c > b) {
+      return undefined;
+    } else {
+      if (x < a || x > b) {
+        return 0;
+      } else {
+        if (x <= c) {
+          if ( c === a) {
+            return 1.0;
+          } else {
+            return (2 * (x - a)) / ((b - a) * (c - a));
+          }
+        } else {
+          if (c === b) {
+            return 1.0;
+          } else {
+            return (2 * (b - x)) / ((b - a) * (b - c));
+          }
+        }
+      }
+    }
   },
 
   cdf: function cdf(x, a, b, c) {

--- a/test/distribution/triangular-test.js
+++ b/test/distribution/triangular-test.js
@@ -1,0 +1,22 @@
+var vows = require('vows');
+var assert = require('assert');
+var suite = vows.describe('jStat.distribution');
+
+require('../env.js');
+
+suite.addBatch({
+  'triangular pdf': {
+    'topic': function() {
+      return jStat;
+    },
+    // checked against R's dtriangle(x, a, b, c) from package 'triangle'
+    'check pdf calculation': function(jStat) {
+      var tol = 0.0000001;
+      assert.epsilon(tol, jStat.triangular.pdf(5.5, 1, 10, 5), 0.2);
+      assert.epsilon(tol, jStat.triangular.pdf(1.0, 1.0, 2.0, 1.0), 1.0);
+      assert.epsilon(tol, jStat.triangular.pdf(3.0, 1.0, 3.0, 3.0), 1.0);
+    },
+  }
+});
+
+suite.export(module);


### PR DESCRIPTION
The triangular pdf suffered from a bug in which, when `c === a`
( `c === b`), the function would return `NaN`. Special cases added to
avoid dividing by `c - a` (`c - b`).