### PR TITLE
Fix Makefile for OSX 10.8, close #126

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ JS_TESTER = $(NODE_PATH)/vows/bin/vows
 DOC_DIR = doc
 BUILD_DIR = build
 DOC_LIST = `ls $(DOC_DIR)/md/`
-JS_ENGINE ?= $(shell which node nodejs 2>/dev/null | grep -Po -m 1 "(.+?)$$")
+JS_ENGINE ?= $(shell which node nodejs 2>/dev/null | head -1)
 
 all: clean core doc
 


### PR DESCRIPTION
OSX 10.8 doesn't have a new enough version of grep to use the -P flag. 

I don't have OSX, so if someone can confirm that the head command is on OSX, that would be excellent. 

This was tested on Xubuntu 14.04 with two versions of Node installed (0.11.3 and 0.12.0), one as node and one as nodejs, with GNU Make 3.81 and GNU Bash 4.3.11(1)-release.