### PR TITLE
Fix #133, with tests

### DIFF
--- a/src/distribution.js
+++ b/src/distribution.js
@@ -102,7 +102,7 @@ jStat.extend(jStat.beta, {
   },
 
   mode: function mode(alpha, beta) {
-    return (alpha * beta) / (Math.pow(alpha + beta, 2) * (alpha + beta + 1));
+    return (alpha - 1 ) / ( alpha + beta - 2);
   },
 
   // return a random sample

--- a/test/distribution/beta-test.js
+++ b/test/distribution/beta-test.js
@@ -38,6 +38,11 @@ suite.addBatch({
 
       assert.equal(jStat.beta.pdf(0, 1, 4), 4);
       assert.equal(jStat.beta.pdf(1, 4, 1), 4);
+    },
+    'check mode calculation': function(jStat) {
+      var tol = 0.0000001;
+      assert.epsilon(tol, jStat.beta.mode(5, 10), 0.307692);
+      assert.epsilon(tol, jStat.beta.moda(2.05, 2), 0.0523691);
     }
   }
 });


### PR DESCRIPTION
The formula for the mode of the beta distribution was incorrect.
Corrected using Wolfram Alpha as test reference.