### PR TITLE
Fix #106

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,34 +11,19 @@ JS_ENGINE ?= $(shell which node nodejs 2>/dev/null | head -1)
 all: clean core doc
 
 clean:
-	@echo 'Cleaning up build files'
-	@rm -rf dist
+	@npm run-script clean
 
-core: jstat.js jstat.min.js
+core:
+	@npm run-script jstatmin
 
-jstat.js: \
-	src/core.js \
-	src/vector.js \
-	src/special.js \
-	src/distribution.js \
-	src/linearalgebra.js \
-	src/test.js
-	@echo 'Building jStat'
-	@mkdir -p $(DIST_DIR)
-	@cat $^ > $(DIST_DIR)/$@
+jstat.js:
+	@npm run-script jstat
 
 jstat.min.js: jstat.js
-	@echo 'Minifying jStat'
-	@$(JS_COMPILER) < $(DIST_DIR)/$< > $(DIST_DIR)/$@
+	@npm run-script jstatmin
 
 doc:
-	@echo 'Generating documentation'
-	@mkdir -p $(DIST_DIR)/docs/assets
-	@cp $(DOC_DIR)/assets/*.css $(DIST_DIR)/docs/assets/
-	@cp $(DOC_DIR)/assets/*.js $(DIST_DIR)/docs/assets/
-	@for i in $(DOC_LIST); do \
-		$(JS_ENGINE) $(BUILD_DIR)/doctool.js $(DOC_DIR)/assets/template.html $(DOC_DIR)/md/$${i} $(DIST_DIR)/docs/$${i%.*}.html; \
-	done
+	@npm run-script doc
 
 jstat: jstat.js
 
@@ -48,7 +33,6 @@ install:
 	@npm install
 
 test: clean core
-	@echo 'Running jStat unit tests'
-	@$(JS_TESTER)
+	@npm run-script test
 
 .PHONY: clean core doc install test

--- a/build/docs.js
+++ b/build/docs.js
@@ -1,0 +1,25 @@
+/*
+	Build the docs
+*/
+
+var fs = require("fs");
+var path = require("path");
+var mkdirp = require('mkdirp');
+
+var file_names = ["./src/core.js", "./src/vector.js", "./src/special.js",
+                  "./src/distribution.js", "./src/linearalgebra.js", "./src/test.js"];
+var files = [];
+
+mkdirp('dist', function(err) {
+  if(err) {
+    console.error(err)
+  }
+});
+
+for(var i = 0; i < file_names.length; i++) {
+  files.push(fs.readFileSync(file_names[i]));
+}
+
+fs.writeFileSync('./dist/jstat.js', Buffer.concat(files));
+
+

--- a/build/jstat.js
+++ b/build/jstat.js
@@ -1,0 +1,24 @@
+/*
+	Build jStat
+*/
+
+var fs = require("fs");
+var path = require("path");
+var mkdirp = require('mkdirp');
+
+var file_names = ["./src/core.js", "./src/vector.js", "./src/special.js",
+                  "./src/distribution.js", "./src/linearalgebra.js", "./src/test.js"];
+var files = [];
+
+mkdirp('dist', function(err) {
+  if(err) {
+    console.error(err)
+  }
+});
+
+for(var i = 0; i < file_names.length; i++) {
+  files.push(fs.readFileSync(file_names[i]));
+}
+
+fs.writeFileSync('./dist/jstat.js', Buffer.concat(files));
+

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "doc"  : "echo 'Generating documentation'; mkdir -p ./dist/docs/assets; cp ./doc/assets/*.css ./dist/docs/assets; cp ./doc/assets/*.js ./dist/docs/assets; for i in `ls ./doc/md/`; do node build/doctool.js ./doc/assets/template.html ./doc/md/${i} ./dist/docs/${i%.*}.html; done",
     "jstat": "echo 'Building jstat'; mkdir -p ./dist; cat ./src/core.js ./src/vector.js ./src/special.js ./src/distribution.js ./src/linearalgebra.js ./src/test.js  > ./dist/jstat.js",
     "jstatmin" : "npm run-script jstat; echo 'Minifying jStat'; (./node_modules/uglify-js/bin/uglifyjs < ./dist/jstat.js) > ./dist/jstat.min.js;",
-    "test" : "npm run-script clean; npm run-script jstatmin; ./node_modules/vows/bin/vows --spec --isolate"
+    "test" : "npm run-script clean; npm run-script jstatmin; ./node_modules/vows/bin/vows"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "devDependencies" : {
     "uglify-js" : "1.2.3",
     "vows" : "https://github.com/flatiron/vows/archive/master.tar.gz"
+    "install": "^0.1.8",
+    "mkdirp": "^0.5.1",
+    "npm": "^2.11.3"  
   },
   "scripts" : {
     "clean": "echo 'Cleaning up build files'; rm -rf dist",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "vows" : "https://github.com/flatiron/vows/archive/master.tar.gz"
   },
   "scripts" : {
-    "test" : "./node_modules/vows/bin/vows --spec --isolate"
+    "clean": "echo 'Cleaning up build files'; rm -rf dist",
+    "doc"  : "echo 'Generating documentation'; mkdir -p ./dist/docs/assets; cp ./doc/assets/*.css ./dist/docs/assets; cp ./doc/assets/*.js ./dist/docs/assets; for i in `ls ./doc/md/`; do node build/doctool.js ./doc/assets/template.html ./doc/md/${i} ./dist/docs/${i%.*}.html; done",
+    "jstat": "echo 'Building jstat'; mkdir -p ./dist; cat ./src/core.js ./src/vector.js ./src/special.js ./src/distribution.js ./src/linearalgebra.js ./src/test.js  > ./dist/jstat.js",
+    "jstatmin" : "npm run-script jstat; echo 'Minifying jStat'; (./node_modules/uglify-js/bin/uglifyjs < ./dist/jstat.js) > ./dist/jstat.min.js;",
+    "test" : "npm run-script clean; npm run-script jstatmin; ./node_modules/vows/bin/vows --spec --isolate"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
   },
   "devDependencies" : {
     "uglify-js" : "1.2.3",
-    "vows" : "https://github.com/flatiron/vows/archive/master.tar.gz"
+    "vows" : "https://github.com/flatiron/vows/archive/master.tar.gz",
     "install": "^0.1.8",
     "mkdirp": "^0.5.1",
-    "npm": "^2.11.3"  
+    "npm": "^2.11.3"
   },
   "scripts" : {
     "clean": "echo 'Cleaning up build files'; rm -rf dist",


### PR DESCRIPTION
Instead of moving to Grunt or Gulp, put the scripts we need into our
package.json file. To maintain backwards compatibility with existing
build setups, the Makefile is retained, but now refers to scripts
defined in package.json using calls to npm run-script.

This removes the dependence on make for users on windows or platforms
without a current or up to date version of make, and should make
contributing to the project easier.

I left the defaults for vows (--isolate) that were already in
package.json, even though those were different from the defaults in the
Makefile. Perosnally, I prefer the less verbose vows output, and would
love to change this.
