### PR TITLE
Add a version number, close #105

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -5,6 +5,11 @@ var concat = Array.prototype.concat;
 var slice = Array.prototype.slice;
 var toString = Object.prototype.toString;
 
+// Specify a version number
+function version() {
+  return "1.2.3";
+}
+
 // Calculate correction for IEEE error
 // TODO: This calculation can be improved.
 function calcRdx(n, m) {

--- a/test/core/version-test.js
+++ b/test/core/version-test.js
@@ -1,0 +1,19 @@
+var vows = require('vows');
+var assert = require('assert');
+var suite = vows.describe('jStat.alter');
+
+require('../env.js');
+
+suite.addBatch({
+  'version': {
+    'topic': function() {
+      return jStat;
+    },
+    'has version': function(jStat) {
+      assert.isNotNull(jStat.version());
+    }
+  }
+});
+
+suite.export(module);
+


### PR DESCRIPTION
I tried to predict which version this would land in, but of course it
will need to be bumped every release.

This would fulfill #105 but does add another step to the release
process. Personally, I am indifferent to whether or not the library
should provide a .version(), but if not, we should explicitly close
issue #105.
