### PR TITLE
Update documentation and add test for mode(true)

### DIFF
--- a/doc/md/vector.md
+++ b/doc/md/vector.md
@@ -458,15 +458,9 @@ If callback is passed then will pass result as first argument.
         // result === false
     });
 
-If pass boolean true as first argument, then return mode of the matrix.
+If pass boolean true as first argument, then the matrix will be treated as one dimensional.
 
-    jStat([[1,2],[1,2]]).mode( true ) === [[1,2],[1,2]]
-
-And the two can be combined.
-
-    jStat([[1,2],[1,2]]).mode(true,function( result ) {
-        // result === false
-    });
+    jStat([[5,4],[5, 2], [5,2]]).mode( true ) === 5
 
 ### range()
 

--- a/test/vector/mode-test.js
+++ b/test/vector/mode-test.js
@@ -33,6 +33,15 @@ suite.addBatch({
     },
     'mode matrix cols callback': function(val, stat) {
       assert.deepEqual(val, [1, [2, 4]]);
+    },
+  },
+  'mode of a matrix': {
+    'topic': function() {
+      return jStat;
+    },
+    'mode matrix columns with true returns the "mode of the matrix"': function() {
+      assert.equal(jStat([[1, 2], [1, 4], [1, 4]]).mode(true), 1);
+      assert.equal(jStat([[5, 2], [5, 4], [5, 4]]).mode(true), 5);
     }
   }
 });


### PR DESCRIPTION
The documentation previously specified that jStat(<two dimensional
array>).mode(true) returned 'the mode of the array', i.e. the most
common row. However, inspection of the .mode() function shows that
.mode(true) instead treats the two-dimensional array as one dimensional.

I believe this is a reasonable method option; as far as I can tell there
is no commonly accepted definition for 'the mode of an array'. If there
is strong demand for 'finding the most common data point in my two
dimensional data', it would be better to define it explicitly.

Add a test to verify this behavior and update the documentation to
reflect this.

This should close #50, which is out of date.