### PR TITLE
Add quantile function for Pareto distribution: pareto.inv()

### DIFF
--- a/src/distribution.js
+++ b/src/distribution.js
@@ -535,6 +535,10 @@ jStat.extend(jStat.pareto, {
     return 1 - Math.pow(scale / x, shape);
   },
 
+  inv: function inv(p, scale, shape) {
+    return scale / Math.pow(1 - p, 1 / shape);
+  },
+
   mean: function mean(scale, shape) {
     if (shape <= 1)
       return undefined;

--- a/test/distribution/pareto-test.js
+++ b/test/distribution/pareto-test.js
@@ -1,0 +1,36 @@
+var vows = require('vows');
+var assert = require('assert');
+var suite = vows.describe('jStat.distribution');
+
+require('../env.js');
+
+suite.addBatch({
+  'pareto inv': {
+    'topic': function() {
+      return jStat;
+    },
+    // Checked against R's qpareto(x, df) in package VGAM
+    //   install.packages("VGAM")
+    //   library("VGAM")
+    //   options(digits=10)
+    //   qpareto(c(0, 0.5, 1), 1, 1)
+    //   qpareto(c(0, 0.5, 1), 1, 2)
+    //   qpareto(c(0, 0.5, 1), 2, 2)
+    'check inv calculation': function(jStat) {
+      var tol = 0.0000001;
+      assert.epsilon(tol, jStat.pareto.inv(0, 1, 1), 1);
+      assert.epsilon(tol, jStat.pareto.inv(0.5, 1, 1), 2);
+      assert.equal(jStat.pareto.inv(1, 1, 1), Infinity);
+
+      assert.epsilon(tol, jStat.pareto.inv(0, 1, 2), 1);
+      assert.epsilon(tol, jStat.pareto.inv(0.5, 1, 2), 1.414213562);
+      assert.equal(jStat.pareto.inv(1, 1, 2), Infinity);
+
+      assert.epsilon(tol, jStat.pareto.inv(0, 2, 2), 2);
+      assert.epsilon(tol, jStat.pareto.inv(0.5, 2, 2), 2.828427125);
+      assert.equal(jStat.pareto.inv(1, 2, 2), Infinity);
+    }
+  },
+});
+
+suite.export(module);


### PR DESCRIPTION
The Pareto distribution did not have a quantile function (inverse
cumulative distribution function) defined. The math for this function is
based on the formula qf defined here:
http://www.distributome.org/js/DistributomeDBSearch.xml.php?s=pareto