### PR TITLE
Fix issue #97: centralF.pdf() returns NaN when x = 0 and df1 <= 2

### DIFF
--- a/src/distribution.js
+++ b/src/distribution.js
@@ -128,10 +128,10 @@ jStat.extend(jStat.centralF, {
       return undefined;
 
     if (df1 <= 2) {
-      if (df1 === 1 && df2 === 1) {
+      if (x === 0 && df1 < 2) {
         return Infinity;
       }
-      if (df1 === 2 && df2 === 1) {
+      if (x === 0 && df1 === 2) {
         return 1;
       }
       return Math.sqrt((Math.pow(df1 * x, df1) * Math.pow(df2, df2)) /

--- a/test/distribution/central-f-test.js
+++ b/test/distribution/central-f-test.js
@@ -37,6 +37,13 @@ suite.addBatch({
       var third_at_zero = jStat.centralF.pdf(0.0, 1, 1);
       assert.strictEqual(third_at_zero, Infinity);
 
+      // When x = 0, and df1 = 2, return 1
+      //   df(0, 2, 15)
+      assert.epsilon(tol, jStat.centralF.pdf(0, 2, 15), 1);
+
+      // When x = 0, and df1 < 2, return Infinity
+      //   df(0, 1, 20)
+      assert.equal(jStat.centralF.pdf(0, 1, 20), Infinity);      
     }
   },
 });


### PR DESCRIPTION
When x = 0 and df1 <= 2, the pdf was still returning NaN. There were a
couple of checks in the code that appeared to be intended to deal with
this situation, but they weren't conditional on x = 0, when they should,
and they were conditional on the value of df2, when they shouldn't. This
fixes those problems.