### PR TITLE
Fix for issue #98: chisquare.pdf() when x = 0

### DIFF
--- a/src/distribution.js
+++ b/src/distribution.js
@@ -210,7 +210,7 @@ jStat.extend(jStat.cauchy, {
 // extend chisquare function with static methods
 jStat.extend(jStat.chisquare, {
   pdf: function pdf(x, dof) {
-    return x === 0 ? 0 :
+    return (x === 0 && dof === 2) ? 0.5 :
         Math.exp((dof / 2 - 1) * Math.log(x) - x / 2 - (dof / 2) *
                  Math.log(2) - jStat.gammaln(dof / 2));
   },

--- a/test/distribution/chisquare-test.js
+++ b/test/distribution/chisquare-test.js
@@ -14,9 +14,15 @@ suite.addBatch({
       var tol = 0.0000001;
       assert.epsilon(tol, jStat.chisquare.pdf(3.5, 10), 0.03395437);
     },
+    // Checked against R dchisq(x,df)
+    //   dchisq(0, 5)
+    //   dchisq(0, 2)
+    //   dchisq(0, 1)
     'check pdf calculation at x = 0.0': function(jStat) {
       var tol = 0.0000001;
       assert.epsilon(tol, jStat.chisquare.pdf(0.0, 5), 0.0);
+      assert.epsilon(tol, jStat.chisquare.pdf(0.0, 2), 0.5);
+      assert.equal(jStat.chisquare.pdf(0.0, 1), Infinity);
     },
     //Checked against R's pchisq(x, df)
     'check cdf calculation': function(jStat) {


### PR DESCRIPTION
Fix for issue #98.
The previous fix did not return the correct values for the pdf when x =
0. This commit corrects that. When dof < 2 then the pdf should return
Infinity, when dof > 2 then the pdf should return 0, and when dof = 2
then the pdf should return 0.5. You can confirm these with dchisq() in
R.