### PR TITLE
Fix kumaraswamy.pdf and add tests (Fixes issue #99)

### DIFF
--- a/src/distribution.js
+++ b/src/distribution.js
@@ -355,6 +355,10 @@ jStat.extend(jStat.invgamma, {
 // extend kumaraswamy function with static methods
 jStat.extend(jStat.kumaraswamy, {
   pdf: function pdf(x, alpha, beta) {
+    if (x === 0 && alpha === 1)
+      return beta;
+    else if (x === 1 && beta === 1)
+      return alpha;
     return Math.exp(Math.log(alpha) + Math.log(beta) + (alpha - 1) *
                     Math.log(x) + (beta - 1) *
                     Math.log(1 - Math.pow(x, alpha)));

--- a/test/distribution/kumaraswamy-test.js
+++ b/test/distribution/kumaraswamy-test.js
@@ -1,0 +1,81 @@
+var vows = require('vows');
+var assert = require('assert');
+var suite = vows.describe('jStat.distribution');
+
+require('../env.js');
+
+suite.addBatch({
+  'kumaraswamy pdf': {
+    'topic': function() {
+      return jStat;
+    },
+    // Checked against R's dkumar(p, shape1, shape2, log=FALSE) in package VGAM
+    //   install.packages("VGAM")
+    //   library("VGAM")
+    //   options(digits=10)
+    //   dkumar(c(0, 0.5, 1), 0.5, 0.5)
+    //   dkumar(c(0, 0.5, 1), 0.8, 1) # Note: Incorrectly returns NaN for x = 1!
+    //   dkumar(c(0, 0.5, 1), 1, 0.4) # Note: Incorrectly returns NaN for x = 0!
+    //   dkumar(c(0, 0.5, 1), 0.6, 1.2)
+    //   dkumar(c(0, 0.5, 1), 1.3, 0.5)
+    //   dkumar(c(0, 0.5, 1), 1, 1) # Note: Incorrectly returns NaN for x = 0 and x = 1!
+    //   dkumar(c(0, 0.5, 1), 2, 1) # Note: Incorrectly returns NaN for x = 1!
+    //   dkumar(c(0, 0.5, 1), 1, 1.5) # Note: Incorrectly returns NaN for x = 0!
+    //   dkumar(c(0, 0.5, 1), 1.5, 1.5)
+    //   dkumar(c(0, 0.5, 1), 7, 25)
+'check pdf calculation': function(jStat) {
+      var tol = 0.0000001;
+      // 'U'-shaped distribution
+      assert.equal(jStat.kumaraswamy.pdf(0, 0.5, 0.5), Infinity);
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(0.5, 0.5, 0.5), 0.6532814824);
+      assert.equal(jStat.kumaraswamy.pdf(1, 0.5, 0.5), Infinity);
+
+      // 'L'-shaped distribution
+      assert.equal(jStat.kumaraswamy.pdf(0, 0.8, 1), Infinity);
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(0.5, 0.8, 1), 0.918958684);
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(1, 0.8, 1), 0.8);
+      
+      // reversed-'L'-shaped distribution
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(0, 1, 0.4), 0.4);
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(0.5, 1, 0.4), 0.6062866266);
+      assert.equal(jStat.kumaraswamy.pdf(1, 1, 0.4), Infinity);
+
+      // sideways-'S'-shaped distribution
+      assert.equal(jStat.kumaraswamy.pdf(0, 0.6, 1.2), Infinity);
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(0.5, 0.6, 1.2), 0.7657783992);
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(1, 0.6, 1.2), 0);
+
+      // sideways-'Z'-shaped distribution
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(0, 1.3, 0.5), 0);
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(0.5, 1.3, 0.5), 0.6851052165);
+      assert.equal(jStat.kumaraswamy.pdf(1, 1.3, 0.5), Infinity);
+
+      // flat distribution
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(0, 1, 1), 1);
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(0.5, 1, 1), 1);
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(1, 1, 1), 1);
+
+      // '/'-shaped distribution
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(0, 2, 1), 0);
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(0.5, 2, 1), 1);
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(1, 2, 1), 2);
+
+      // '\'-shaped distribution
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(0, 1, 1.5), 1.5);
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(0.5, 1, 1.5), 1.060660172);
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(1, 1, 1.5), 0);
+
+      // inverted-'U'-shaped distribution
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(0, 1.5, 1.5), 0);
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(0.5, 1.5, 1.5), 1.279186452);
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(1, 1.5, 1.5), 0);
+
+      // peaked distribution
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(0, 7, 25), 0);
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(0.5, 7, 25), 2.265208101);
+      assert.epsilon(tol, jStat.kumaraswamy.pdf(1, 7, 25), 0);
+    }
+  },
+});
+
+suite.export(module);


### PR DESCRIPTION
This PR fixes issue #99.

Add special cases for the two instances where the 'log' form of the PDF
fails (when x = 0 and alpha = 1, and when x = 1, and beta = 1).

Also added extensive tests for the kumaraswamy.pdf() based on dkumar()
in R package VGAM. Note that there are a few cases where the R function
incorrectly returns NaN. You can confirm the correct values in these
cases by doing the math using the function for the PDF here:
https://en.wikipedia.org/wiki/Kumaraswamy_distribution