### PR TITLE
Fix for issue #104: Some CDF functions return incorrect values outside of support 

### DIFF
--- a/src/distribution.js
+++ b/src/distribution.js
@@ -146,6 +146,8 @@ jStat.extend(jStat.centralF, {
   },
 
   cdf: function cdf(x, df1, df2) {
+    if (x < 0)
+      return 0;
     return jStat.ibeta((df1 * x) / (df1 * x + df2), df1 / 2, df2 / 2);
   },
 
@@ -216,6 +218,8 @@ jStat.extend(jStat.chisquare, {
   },
 
   cdf: function cdf(x, dof) {
+    if (x < 0)
+      return 0;
     return jStat.lowRegGamma(dof / 2, x / 2);
   },
 
@@ -292,6 +296,8 @@ jStat.extend(jStat.gamma, {
   },
 
   cdf: function cdf(x, shape, scale) {
+    if (x < 0)
+      return 0;
     return jStat.lowRegGamma(shape, x / scale);
   },
 
@@ -325,6 +331,8 @@ jStat.extend(jStat.invgamma, {
   },
 
   cdf: function cdf(x, shape, scale) {
+    if (x <= 0)
+      return 0;
     return 1 - jStat.lowRegGamma(shape, scale / x);
   },
 
@@ -361,6 +369,10 @@ jStat.extend(jStat.kumaraswamy, {
   },
 
   cdf: function cdf(x, alpha, beta) {
+    if (x < 0)
+      return 0;
+    else if (x > 1)
+      return 1;
     return (1 - Math.pow(1 - Math.pow(x, alpha), beta));
   },
 
@@ -396,6 +408,8 @@ jStat.extend(jStat.lognormal, {
   },
 
   cdf: function cdf(x, mu, sigma) {
+    if (x < 0)
+      return 0;
     return 0.5 +
         (0.5 * jStat.erf((Math.log(x) - mu) / Math.sqrt(2 * sigma * sigma)));
   },
@@ -532,6 +546,8 @@ jStat.extend(jStat.pareto, {
   },
 
   cdf: function cdf(x, scale, shape) {
+    if (x < scale)
+      return 0;
     return 1 - Math.pow(scale / x, shape);
   },
 
@@ -978,16 +994,15 @@ jStat.extend(jStat.triangular, {
 
   cdf: function cdf(x, a, b, c) {
     if (b <= a || c < a || c > b)
-      return undefined;
-    if (x < a) {
+      return NaN;
+    if (x <= a)
       return 0;
-    } else {
-      if (x <= c)
-        return Math.pow(x - a, 2) / ((b - a) * (c - a));
+    else if (x >= b)
+      return 1;
+    if (x <= c)
+      return Math.pow(x - a, 2) / ((b - a) * (c - a));
+    else // x > c
       return 1 - Math.pow(b - x, 2) / ((b - a) * (b - c));
-    }
-    // never reach this
-    return 1;
   },
 
   mean: function mean(a, b, c) {

--- a/test/distribution/central-f-test.js
+++ b/test/distribution/central-f-test.js
@@ -37,8 +37,34 @@ suite.addBatch({
       var third_at_zero = jStat.centralF.pdf(0.0, 1, 1);
       assert.strictEqual(third_at_zero, Infinity);
 
+    },
+    // Check against R's pf(q, df1, df2, ncp, lower.tail = TRUE, log.p = FALSE):
+    //    options(digits=10)
+    //    pf(0.2, 1, 3)
+    //    pf(1, 100, 100)
+    //    pf(2.5, 50, 200)
+    //    pf(0.8, 2, 10)
+    //    pf(0.4, 3, 10)
+    //    pf(0, 3, 5)
+    //    pf(0, 2, 1)
+    //    pf(0, 1, 1)
+    //    pf(-5, 5, 20)
+    'check cdf calculation': function(jStat) {
+      var tol = 0.0000001;
+      // Check with x within support (x > 0)
+      assert.epsilon(tol, jStat.centralF.cdf(0.2, 1, 3), 0.3149623575);
+      assert.epsilon(tol, jStat.centralF.cdf(1, 100, 100), 0.5);
+      assert.epsilon(tol, jStat.centralF.cdf(2.5, 50, 200), 0.9999962786);
+      assert.epsilon(tol, jStat.centralF.cdf(0.8, 2, 10), 0.5238869846);
+      assert.epsilon(tol, jStat.centralF.cdf(0.4, 3, 10), 0.2439174275);
+      // Check with x at edge of support (x = 0)
+      assert.epsilon(tol, jStat.centralF.cdf(0.0, 3, 5), 0);
+      assert.epsilon(tol, jStat.centralF.cdf(0.0, 2, 1), 0);
+      assert.epsilon(tol, jStat.centralF.cdf(0.0, 1, 1), 0);
+      // Check with x outside of support (x < 0)
+      assert.epsilon(tol, jStat.centralF.cdf(-5, 5, 20), 0);
     }
-  },
+  }
 });
 
 suite.export(module);

--- a/test/distribution/chisquare-test.js
+++ b/test/distribution/chisquare-test.js
@@ -23,6 +23,12 @@ suite.addBatch({
       var tol = 0.0000001;
       assert.epsilon(tol, jStat.chisquare.cdf(2.5, 8), 0.03826905);
     },
+    // Checked against R's pchisq(q, df, ncp = 0, lower.tail = TRUE, log.p = FALSE):
+    //    pchisq(-5, 21)
+    'check cdf calculation when x outside support (x < 0)': function(jStat) {
+      var tol = 0.0000001;
+      assert.epsilon(tol, jStat.chisquare.cdf(-5, 21), 0);
+    },
     //Checked against R's qchisq(x, df)
     'check inv calculation': function(jStat) {
       var tol = 0.00001;

--- a/test/distribution/gamma-test.js
+++ b/test/distribution/gamma-test.js
@@ -36,6 +36,7 @@ suite.addBatch({
       assert.epsilon(tol, jStat.gamma.cdf(2, 1, 1), 0.8646647);
       assert.epsilon(tol, jStat.gamma.cdf(5, 10, 2), 0.0002773);
       assert.epsilon(tol, jStat.gamma.cdf(18, 22, 0.8), 0.5701725);
+      assert.epsilon(tol, jStat.gamma.cdf(-1, 5, 5), 0);
     },
 
     //Checked against R's qgamma(p, shape, rate = 1/scale)

--- a/test/distribution/inverse-gamma-test.js
+++ b/test/distribution/inverse-gamma-test.js
@@ -17,6 +17,7 @@ suite.addBatch({
       assert.epsilon(tol, jStat.invgamma.cdf(0.5, 1, 1), 0.1353353);
       assert.epsilon(tol, jStat.invgamma.cdf(0.25, 10, 2), 0.7166243);
       assert.epsilon(tol, jStat.invgamma.cdf(0.95, 18, 10), 0.9776673);
+      assert.epsilon(tol, jStat.invgamma.cdf(-5, 5, 20), 0);
     },
 
     //Checked against R's qigamma(p, shape, rate = 1/scale)

--- a/test/distribution/kumaraswamy-test.js
+++ b/test/distribution/kumaraswamy-test.js
@@ -1,0 +1,86 @@
+var vows = require('vows');
+var assert = require('assert');
+var suite = vows.describe('jStat.distribution');
+
+require('../env.js');
+
+suite.addBatch({
+  'kumaraswamy cdf': {
+    'topic': function() {
+      return jStat;
+    },
+    // Checked against R's pkumar(q, shape1, shape2, lower.tail = TRUE, log.p = FALSE) in package VGAM
+    //   install.packages("VGAM")
+    //   library("VGAM")
+    //   options(digits=10)
+    //   pkumar(c(0, 0.5, 1), 0.5, 0.5)
+    //   pkumar(c(0, 0.5, 1), 0.8, 1) # Note: Incorrectly returns NaN for x = 1!
+    //   pkumar(c(0, 0.5, 1), 1, 0.4) # Note: Incorrectly returns NaN for x = 0!
+    //   pkumar(c(0, 0.5, 1), 0.6, 1.2)
+    //   pkumar(c(0, 0.5, 1), 1.3, 0.5)
+    //   pkumar(c(0, 0.5, 1), 1, 1) # Note: Incorrectly returns NaN for x = 0 and x = 1!
+    //   pkumar(c(0, 0.5, 1), 2, 1) # Note: Incorrectly returns NaN for x = 1!
+    //   pkumar(c(0, 0.5, 1), 1, 1.5) # Note: Incorrectly returns NaN for x = 0!
+    //   pkumar(c(0, 0.5, 1), 1.5, 1.5)
+    //   pkumar(c(0, 0.5, 1), 7, 25)
+	//	 pkumar(c(-5, 5), 2, 2)
+	'check cdf calculation': function(jStat) {
+      var tol = 0.0000001;
+      // 'U'-shaped distribution
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0, 0.5, 0.5), 0);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0.5, 0.5, 0.5), 0.4588038999);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(1, 0.5, 0.5), 1);
+
+      // 'L'-shaped distribution
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0, 0.8, 1), 0);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0.5, 0.8, 1), 0.5743491775);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(1, 0.8, 1), 1);
+      
+      // reversed-'L'-shaped distribution
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0, 1, 0.4), 0);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0.5, 1, 0.4), 0.2421417167);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(1, 1, 0.4), 1);
+
+      // sideways-'S'-shaped distribution
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0, 0.6, 1.2), 0);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0.5, 0.6, 1.2), 0.7257468009);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(1, 0.6, 1.2), 1);
+
+      // sideways-'Z'-shaped distribution
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0, 1.3, 0.5), 0);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0.5, 1.3, 0.5), 0.2293679206);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(1, 1.3, 0.5), 1);
+
+      // flat distribution
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0, 1, 1), 0);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0.5, 1, 1), 0.5);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(1, 1, 1), 1);
+
+      // '/'-shaped distribution
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0, 2, 1), 0);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0.5, 2, 1), 0.25);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(1, 2, 1), 1);
+
+      // '\'-shaped distribution
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0, 1, 1.5), 0);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0.5, 1, 1.5), 0.6464466094);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(1, 1, 1.5), 1);
+
+      // inverted-'U'-shaped distribution
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0, 1.5, 1.5), 0);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0.5, 1.5, 1.5), 0.4802446206);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(1, 1.5, 1.5), 1);
+
+      // peaked distribution
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0, 7, 25), 0);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(0.5, 7, 25), 0.1780530605);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(1, 7, 25), 1);
+
+      // outside support
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(-5, 2, 2), 0);
+      assert.epsilon(tol, jStat.kumaraswamy.cdf(5, 2, 2), 1);
+    }
+  },
+});
+
+suite.export(module);

--- a/test/distribution/lognormal-test.js
+++ b/test/distribution/lognormal-test.js
@@ -1,0 +1,24 @@
+var vows = require('vows');
+var assert = require('assert');
+var suite = vows.describe('jStat.distribution');
+
+require('../env.js');
+
+suite.addBatch({
+  'lognormal cdf': {
+    'topic': function() {
+      return jStat;
+    },
+    // Checked against R's plnorm(q, meanlog = 0, sdlog = 1, lower.tail = TRUE, log.p = FALSE)
+    //   options(digits=10)
+	//	 plnorm(c(-2, 0, 4), 4, 5)
+	'check cdf calculation': function(jStat) {
+      var tol = 0.0000001;
+      assert.epsilon(tol, jStat.lognormal.cdf(-2, 4, 5), 0);
+      assert.epsilon(tol, jStat.lognormal.cdf(0, 4, 5), 0);
+      assert.epsilon(tol, jStat.lognormal.cdf(4, 4, 5), 0.3005772067);
+    }
+  },
+});
+
+suite.export(module);

--- a/test/distribution/pareto-test.js
+++ b/test/distribution/pareto-test.js
@@ -1,0 +1,34 @@
+var vows = require('vows');
+var assert = require('assert');
+var suite = vows.describe('jStat.distribution');
+
+require('../env.js');
+
+suite.addBatch({
+  'pareto cdf': {
+    'topic': function() {
+      return jStat;
+    },
+    // Checked against R's ppareto(q, scale = 1, shape, lower.tail = TRUE, log.p = FALSE) in package VGAM
+    //   install.packages("VGAM")
+    //   library("VGAM")
+    //   options(digits=10)
+    //   ppareto(c(0, 1, 2), 1, 1)
+    //   ppareto(c(-1, 1, 4), 1, 2)
+    //   ppareto(c(1, 2, 10), 2, 2)
+    'check cdf calculation': function(jStat) {
+      var tol = 0.0000001;
+      assert.epsilon(tol, jStat.pareto.cdf(0, 1, 1), 0);
+      assert.epsilon(tol, jStat.pareto.cdf(1, 1, 1), 0);
+      assert.epsilon(tol, jStat.pareto.cdf(2, 1, 1), 0.5);
+
+      assert.epsilon(tol, jStat.pareto.cdf(-1, 1, 2), 0);
+      assert.epsilon(tol, jStat.pareto.cdf(1, 1, 2), 0);
+      assert.epsilon(tol, jStat.pareto.cdf(4, 1, 2), 0.9375);
+ 
+      assert.epsilon(tol, jStat.pareto.cdf(1, 2, 2), 0);
+      assert.epsilon(tol, jStat.pareto.cdf(2, 2, 2), 0);
+      assert.epsilon(tol, jStat.pareto.cdf(10, 2, 2), 0.96);
+    }
+  },
+});

--- a/test/distribution/triangular-test.js
+++ b/test/distribution/triangular-test.js
@@ -16,6 +16,59 @@ suite.addBatch({
       assert.epsilon(tol, jStat.triangular.pdf(1.0, 1.0, 2.0, 1.0), 1.0);
       assert.epsilon(tol, jStat.triangular.pdf(3.0, 1.0, 3.0, 3.0), 1.0);
     },
+  },
+  'triangular cdf': {
+    'topic': function() {
+      return jStat;
+    },
+    // checked against R's ptriang(q, min=-1, mode=0, max=1, lower.tail=TRUE, log.p=FALSE) from package 'mc2d':
+    //   install.packages("mc2d")
+    //   library("mc2d")
+    //   options(digits=10)
+    //   ptriang(c(0, 1, 3, 5, 7, 11, 13), 1, 5, 11)
+    //   ptriang(c(-10, -5, 0, 5, 10), -5, -5, 5)
+    //   ptriang(c(-1, 0, 4, 8, 10), 0, 8, 8)
+    //   ptriang(6, 5, 4, 10)
+    //   ptriang(30, 23, 50, 47)
+    //   ptriang(-10, -10, -10, -10) # NOTE: This returns: [1] 1, but we don't allow a = b = c!   
+    'check cdf calculation, when a < c < b': function(jStat) {
+      var tol = 0.0000001;
+      assert.epsilon(tol, jStat.triangular.cdf(0, 1, 11, 5), 0);
+      assert.epsilon(tol, jStat.triangular.cdf(1, 1, 11, 5), 0);
+      assert.epsilon(tol, jStat.triangular.cdf(3, 1, 11, 5), 0.1);
+      assert.epsilon(tol, jStat.triangular.cdf(5, 1, 11, 5), 0.4);
+      assert.epsilon(tol, jStat.triangular.cdf(7, 1, 11, 5), 0.7333333333);
+      assert.epsilon(tol, jStat.triangular.cdf(11, 1, 11, 5), 1);
+      assert.epsilon(tol, jStat.triangular.cdf(13, 1, 11, 5), 1);
+    },
+    'check cdf calculation, when a = c < b': function(jStat) {
+      var tol = 0.0000001;
+      assert.epsilon(tol, jStat.triangular.cdf(-10, -5, 5, -5), 0);
+      assert.epsilon(tol, jStat.triangular.cdf(-5, -5, 5, -5), 0);
+      assert.epsilon(tol, jStat.triangular.cdf(0, -5, 5, -5), 0.75);
+      assert.epsilon(tol, jStat.triangular.cdf(5, -5, 5, -5), 1);
+      assert.epsilon(tol, jStat.triangular.cdf(10, -5, 5, -5), 1);
+    },
+    'check cdf calculation, when a < c = b': function(jStat) {
+      var tol = 0.0000001;
+      assert.epsilon(tol, jStat.triangular.cdf(-1, 0, 8, 8), 0);
+      assert.epsilon(tol, jStat.triangular.cdf(0, 0, 8, 8), 0);
+      assert.epsilon(tol, jStat.triangular.cdf(4, 0, 8, 8), 0.25);
+      assert.epsilon(tol, jStat.triangular.cdf(8, 0, 8, 8), 1);
+      assert.epsilon(tol, jStat.triangular.cdf(10, 0, 8, 8), 1);
+    },
+    'check cdf calculation, when c < a': function(jStat) {
+      var tol = 0.0000001;
+      assert.isNaN(jStat.triangular.cdf(6, 5, 10, 4));
+    },
+    'check cdf calculation, when b < c': function(jStat) {
+      var tol = 0.0000001;
+      assert.isNaN(jStat.triangular.cdf(30, 23, 47, 50));
+    },
+    'check cdf calculation, when a = b': function(jStat) {
+      var tol = 0.0000001;
+      assert.isNaN(jStat.triangular.cdf(-10, -10, -10, -10));
+    }
   }
 });
 


### PR DESCRIPTION
This fixes issue #104. Fixes for multiple distributions (centralF, chisquare, gamma, invgamma,
kumaraswamy, lognormal, pareto, triangular) so that cdf()s return proper
values outside of support.

Also added testing for these cdf()s. If test already existed, just added
ones outside support, otherwise added multiple tests inside and outside
support.