### PR TITLE
Missing parens in negbin pdf?

### DIFF
--- a/src/distribution.js
+++ b/src/distribution.js
@@ -751,7 +751,7 @@ jStat.extend(jStat.binomial, {
 // extend uniform function with static methods
 jStat.extend(jStat.negbin, {
   pdf: function pdf(k, r, p) {
-    return k !== k | 0
+    return k !== (k | 0)
       ? false
       : k < 0
         ? 0


### PR DESCRIPTION
I think there are a set of missing parens on line 747 in distribution.js . Right now it reads `k !== k | 0` which always evaluate to zero, but I think the statement is meant to check if k is *not* an integer which will happen if you add the parens like this: `k !== (k | 0)`.