### PR TITLE
fix(named-function): using object notation outside of an object

### DIFF
--- a/dist/jstat.js
+++ b/dist/jstat.js
@@ -3518,7 +3518,7 @@ jStat.extend(jStat.fn, {
 });
 
 // internal method for calculating the z-score for a difference of proportions test
-differenceOfProportions: function differenceOfProportions(p1, n1, p2, n2) {
+function differenceOfProportions(p1, n1, p2, n2) {
   if (p1 > 1 || p2 > 1 || p1 <= 0 || p2 <= 0) {
     throw new Error("Proportions should be greater than 0 and less than 1")
   }

--- a/src/test.js
+++ b/src/test.js
@@ -252,7 +252,7 @@ jStat.extend(jStat.fn, {
 });
 
 // internal method for calculating the z-score for a difference of proportions test
-differenceOfProportions: function differenceOfProportions(p1, n1, p2, n2) {
+function differenceOfProportions(p1, n1, p2, n2) {
   if (p1 > 1 || p2 > 1 || p1 <= 0 || p2 <= 0) {
     throw new Error("Proportions should be greater than 0 and less than 1")
   }


### PR DESCRIPTION
Function is being referenced using objection notation as well as a named function, which has a use case, however in this case it's not applicable since the object notation is sitting outside of an object.  This is causing a build error in my app when it tries to bundle through JSPM.