### PR TITLE
Fix #161 - Dead links on TOC page

### DIFF
--- a/build/doctool.js
+++ b/build/doctool.js
@@ -85,6 +85,7 @@ function convertData(data) {
 	// Convert it to HTML from Markdown
 	var html = markdown.toHTML(markdown.parse(data), {xhtml:true})
 		.replace(/<hr><\/hr>/g, "<hr />")
+		.replace(/\.md/g, ".html")
 		.replace(/(\<h[2-6])\>([^<]+)(\<\/h[1-6]\>)/gmi, function(o, ts, c, te) {
 			return ts+' id="'+formatIdString(c)+'">'+c+te;
 		});

--- a/doc/md/_toc.md
+++ b/doc/md/_toc.md
@@ -1,9 +1,9 @@
 ## Table of Contents
 
-* [Overview](overview.html)
-* [Core](core.html)
-* [Vector](vector.html)
-* [Special Functions](special-functions.html)
-* [Distributions](distributions.html)
-* [Linear Algebra](linear-algebra.html)
-* [Statistical Tests](test.html)
+* [Overview](overview.md)
+* [Core](core.md)
+* [Vector](vector.md)
+* [Special Functions](special-functions.md)
+* [Distributions](distributions.md)
+* [Linear Algebra](linear-algebra.md)
+* [Statistical Tests](test.md)


### PR DESCRIPTION
Github helpfully renders the .md files in /doc, but the previous version
of _toc linked to <pagename>.html, which failed. Switching the links to
.md made the links work on github, but broke them in the generated
documentation.

Instead, switch links to .md but replace .md with .html in the doctool.

Tested by generating documentation locally - links work.