### PR TITLE
set correct dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "type" : "git",
     "url" : "http://github.com/jstat/jstat.git"
   },
-  "dependencies" : {
+  "devDependencies" : {
     "uglify-js" : "1.2.3",
     "vows" : "https://github.com/flatiron/vows/archive/master.tar.gz"
   },


### PR DESCRIPTION
From what I can tell, neither vows nor uglify-js are dependencies since they are used to either compile javascript (uglify-js) or test (vows)