### PR TITLE
ENH: Make it easy to explore jstat lib interactively

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ CDN
 The library is hosted on [jsDelivr](http://www.jsdelivr.com/) using the follwing
 url:
 ```
-//cdn.jsdelivr.net/jstat/<version>/jstat.min.js
+//cdn.jsdelivr.net/jstat/latest/jstat.min.js
 ```
 
 Module Loaders

--- a/doc/assets/template.html
+++ b/doc/assets/template.html
@@ -19,6 +19,7 @@
 	</div>
 	<script src="assets/sh_main.js"></script>
 	<script src="assets/sh_javascript.min.js"></script>
+	<script src="//cdn.jsdelivr.net/jstat/latest/jstat.min.js"></script>
 	<script>highlight(undefined, undefined, 'pre');</script>
 </body>
 </html>


### PR DESCRIPTION
Goal:  allow people to explore the jstat library along with the docs.

Possible solutions include:

1.  jsfiddle / codepen like thing, linked from the docs ("explore this at http:...")
2.  Actually include the library in the docs page, via the cdn link.  "Open your webdev prompt... yada yada".

