### PR TITLE
Fix issue #219 - Missing calculation of adjusted R^2

### DIFF
--- a/doc/md/models.md
+++ b/doc/md/models.md
@@ -42,3 +42,7 @@ exactly.
 
 		// f test P-value
 		model.f.pvalue // -> 0.3306363671859872
+
+The adjusted R^2 provided by jStat is the formula variously called the 'Wherry Formula',
+'Ezekiel Formula', 'Wherry/McNemar Formula', or the 'Cohen/Cohen Formula', and is the same
+as the adjusted R^2 value provided by R's `summary.lm` method on a linear model.

--- a/src/models.js
+++ b/src/models.js
@@ -104,8 +104,10 @@ jStat.models = (function(){
     var model = ols(endog,exog);
     var ttest = t_test(model);
     var ftest = F_test(model);
+    // Provide the Wherry / Ezekiel / McNemar / Cohen Adjusted R^2
+    // Which matches the 'adjusted R^2' provided by R's lm package
     var adjust_R2 =
-        1 - (1 - model.rsquared) * ((model.nobs - 1) / (model.df_resid));
+        1 - (1 - model.R2) * ((model.nobs - 1) / (model.df_resid));
     model.t = ttest;
     model.f = ftest;
     model.adjust_R2 = adjust_R2;

--- a/test/models/R2-test.js
+++ b/test/models/R2-test.js
@@ -24,8 +24,18 @@ suite.addBatch({
         var b = [1, -2, 3, 4, -5, 6, 7, -8, 9];
         var model = jStat.models.ols(b, A);
         var tol = 0.01;
-        //R2
+        // R2
         assert.epsilon(tol, model.R2, 0.309);
+        // Adjusted R^2
+        // This Adjusted R^2 is variously called the:
+        // - Wherry Formula
+        // - Ezekiel Formula
+        // - Wherry/McNemar Formula
+        // - Cohen/Cohen Formula
+        //
+        // It is the same as the adjusted R^2 value given by R's linear model
+        // summary method
+        assert.epsilon(tol, model.adjust_R2, 0.078);
         // t test
         assert.epsilon(tol, model.t.p[0], 0.8377444317889267);
         assert.epsilon(tol, model.t.p[1], 0.1529673615844231);


### PR DESCRIPTION
The Ordinary Least Squares module was not computing the adjusted R^2
correctly.

Resolve this issue, additionally adding a test for the correct
calculation, and further document the test, code, and generated
documentation to clarify for users which adjusted R^2 value is being
calcualted.

Thank you to EloquentData for reporting the issue.

Fixes: https://github.com/jstat/jstat/issues/219
PR-URL: https://github.com/jstat/jstat/pulls/