### PR TITLE
Invalid ANOVA F-score returned with two samples

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -129,10 +129,6 @@ jStat.extend({
       }
       args = tmpargs;
     }
-    // 2 sample case
-    if (args.length === 2) {
-      return jStat.variance(args[0]) / jStat.variance(args[1]);
-    }
     // Builds sample array
     sample = new Array();
     for (var i = 0; i < args.length; i++) {


### PR DESCRIPTION
When  `anovafscore()` is given two sample arrays, it treats it as a special case and returns the ratio of the variance of the first sample to that of the second:
https://github.com/jstat/jstat/blob/5d99205d806e72997d863be800ffaf7af1851b97/src/test.js#L134

This is incorrect and leads to invalid F-scores being returned when two samples are given. Additionally, the result is dependent on the order of the parameters, which it should not be.

```javascript
var control = [433.579, 471.484, 487.407, 518.166, 444.534,
               434.615, 447.401, 525.873, 421.322, 425.949];
var test    = [356.139, 315.869, 327.203, 335.308, 332.547,
               336.871, 353.809, 333.462, 349.203, 340.051];

jStat.anovafscore(control, test); // result: 9.455747503728437
jStat.anovafscore(test, control); // result: 0.10575578499803387
```

The proper F-score of the above two samples is approximately 94.769. If the special-case handling of two samples is removed, the proper F-score is returned.