### PR TITLE
Array ranking efficiency

### DIFF
--- a/src/vector.js
+++ b/src/vector.js
@@ -151,21 +151,35 @@ jStat.diff = function diff(arr) {
 
 // ranks of an array
 jStat.rank = function (arr) {
-  var arrlen = arr.length;
-  var sorted = arr.slice().sort(ascNum);
-  var ranks = new Array(arrlen);
-  var val;
-  for (var i = 0; i < arrlen; i++) {
-    var first = sorted.indexOf(arr[i]);
-    var last = sorted.lastIndexOf(arr[i]);
-    if (first === last) {
-      val = first;
+  var i;
+  var distinctNumbers = [];
+  var numberCounts = {};
+  for (i = 0; i < arr.length; i++) {
+    var number = arr[i];
+    if (numberCounts[number]) {
+      numberCounts[number]++;
     } else {
-      val = (first + last) / 2;
+      numberCounts[number] = 1;
+      distinctNumbers.push(number);
     }
-    ranks[i] = val + 1;
   }
-  return ranks;
+
+  var sortedDistinctNumbers = distinctNumbers.sort(ascNum);
+  var numberRanks = {};
+  var currentRank = 1;
+  for (i = 0; i < sortedDistinctNumbers.length; i++) {
+    var number = sortedDistinctNumbers[i];
+    var count = numberCounts[number];
+    var first = currentRank;
+    var last = currentRank + count - 1;
+    var rank = (first + last) / 2;
+    numberRanks[number] = rank;
+    currentRank += count;
+  }
+
+  return arr.map(function (number) {
+    return numberRanks[number];
+  });
 };
 
 


### PR DESCRIPTION
Make array ranking more efficient for longer arrays with more distinct numbers.

For a longer array with a larger variety of numbers, `indexOf` and `lastIndexOf` take longer and are called more frequently. Eliminate the need to call `indexOf` and `lastIndexOf` by using the frequency of each number in the array.

**Sample times taken**
Array of length 100, with random numbers between 1 and 100
- `previous rank: 0.072021484375ms`
- `new rank: 0.054931640625ms`

Array of length 100,000, ascending distinct numbers from 0 through 99,999
- `previous rank: 14851.73291015625ms`
- `new rank: 33.7861328125ms`

Array of length 100,000, with random numbers between 1 and 100
- `previous rank: 14704.958984375ms`
- `new rank: 37.547119140625ms`

**Note that previous rank is slightly faster when all numbers in the array are the same:**
Array of length 1 million, all `1`s
- `previous rank: 53.232177734375ms`
- `new rank: 162.830078125ms`
