### PR TITLE
fix issue #270 for det() on large matrix

### DIFF
--- a/src/linearalgebra.js
+++ b/src/linearalgebra.js
@@ -181,40 +181,32 @@ jStat.extend({
 
   // calculate the determinant of a matrix
   det: function det(a) {
-    var alen = a.length,
-    alend = alen * 2,
-    vals = new Array(alend),
-    rowshift = alen - 1,
-    colshift = alend - 1,
-    mrow = rowshift - alen + 1,
-    mcol = colshift,
-    i = 0,
-    result = 0,
-    j;
-    // check for special 2x2 case
-    if (alen === 2) {
+    if (a.length === 2) {
       return a[0][0] * a[1][1] - a[0][1] * a[1][0];
     }
-    for (; i < alend; i++) {
-      vals[i] = 1;
-    }
-    for (i = 0; i < alen; i++) {
-      for (j = 0; j < alen; j++) {
-        vals[(mrow < 0) ? mrow + alen : mrow ] *= a[i][j];
-        vals[(mcol < alen) ? mcol + alen : mcol ] *= a[i][j];
-        mrow++;
-        mcol--;
+  
+    const dets = [];
+    for (let i = 0; i < a.length; i++) {
+      // build a sub matrix without column `a`
+      const submatrix = [];
+      for (let row = 1; row < a.length; row++) {
+        submatrix[row - 1] = [];
+        for (let col = 0; col < a.length; col++) {
+          if (col < i) {
+            submatrix[row - 1][col] = a[row][col];
+          } else if (col > i) {
+            submatrix[row - 1][col - 1] = a[row][col];
+          }
+        }
       }
-      mrow = --rowshift - alen + 1;
-      mcol = --colshift;
+  
+      var sign = i % 2 ? -1 : 1;
+      dets.push(det(submatrix) * a[0][i] * sign);
     }
-    for (i = 0; i < alen; i++) {
-      result += vals[i];
-    }
-    for (; i < alend; i++) {
-      result -= vals[i];
-    }
-    return result;
+  
+    return dets.reduce(function (acc, v) {
+      return acc + v;
+    }, 0);
   },
 
   gauss_elimination: function gauss_elimination(a, b) {

--- a/src/linearalgebra.js
+++ b/src/linearalgebra.js
@@ -185,7 +185,7 @@ jStat.extend({
       return a[0][0] * a[1][1] - a[0][1] * a[1][0];
     }
   
-    var dets = [];
+    var determinant = 0;
     for (var i = 0; i < a.length; i++) {
       // build a sub matrix without column `i`
       var submatrix = [];
@@ -202,12 +202,10 @@ jStat.extend({
   
       // alternate between + and - between determinants
       var sign = i % 2 ? -1 : 1;
-      dets.push(det(submatrix) * a[0][i] * sign);
+      determinant += det(submatrix) * a[0][i] * sign;
     }
   
-    return dets.reduce(function (acc, v) {
-      return acc + v;
-    }, 0);
+    return determinant
   },
 
   gauss_elimination: function gauss_elimination(a, b) {

--- a/src/linearalgebra.js
+++ b/src/linearalgebra.js
@@ -185,13 +185,13 @@ jStat.extend({
       return a[0][0] * a[1][1] - a[0][1] * a[1][0];
     }
   
-    const dets = [];
-    for (let i = 0; i < a.length; i++) {
-      // build a sub matrix without column `a`
-      const submatrix = [];
-      for (let row = 1; row < a.length; row++) {
+    var dets = [];
+    for (var i = 0; i < a.length; i++) {
+      // build a sub matrix without column `i`
+      var submatrix = [];
+      for (var row = 1; row < a.length; row++) {
         submatrix[row - 1] = [];
-        for (let col = 0; col < a.length; col++) {
+        for (var col = 0; col < a.length; col++) {
           if (col < i) {
             submatrix[row - 1][col] = a[row][col];
           } else if (col > i) {
@@ -200,6 +200,7 @@ jStat.extend({
         }
       }
   
+      // alternate between + and - between determinants
       var sign = i % 2 ? -1 : 1;
       dets.push(det(submatrix) * a[0][i] * sign);
     }

--- a/test/linearalgebra/det-test.js
+++ b/test/linearalgebra/det-test.js
@@ -9,10 +9,26 @@ suite.addBatch({
     'topic': function() {
       return jStat;
     },
+    "test det on 2x2 matrix": function (jStat) {
+      var A = [
+        [4, 6],
+        [3, 8],
+      ];
+      assert.equal(jStat.det(A), 14);
+    },
     'test det works': function(jStat) {
       var A = [[1, 2, 3], [4, 5, -6], [7, -8, 9]];
       assert.equal(jStat.det(A), -360);
-    }
+    },
+    "test bug #270": function (jStat) {
+      var A = [
+        [310, -228, -190, 108],
+        [-228, 310, 108, -190],
+        [-190, 108, 310, -228],
+        [108, -190, -228, 310],
+      ];
+      assert.equal(jStat.det(A), 0);
+    },
   }
 });
 


### PR DESCRIPTION
This solution uses a recursive algorithm that reiterate sub-matrices until they reach a 2x2 size.

I've added a test for the determinant bug #270 and an additional test for 2x2 matrix.

`make test` Tests are passing