### PR TITLE
update README header jstat.org hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[jStat](http://www.jstat.org/) - JavaScript Statistical Library
+[jStat](https://jstat.github.io/all.html) - JavaScript Statistical Library
 ===============================================================
 
 [![npm version](https://badge.fury.io/js/jstat.svg)](https://badge.fury.io/js/jstat)


### PR DESCRIPTION
The link in the README header was to https://jstat.org, which seems to be separate from this project.  This PR updates the link to point to docs to https://jstat.github.io/all.html 