### PR TITLE
[ENH]  adding `inv` for Laplace distribution

### DIFF
--- a/src/distribution.js
+++ b/src/distribution.js
@@ -1213,7 +1213,8 @@ jStat.extend(jStat.laplace, {
     }
   },
 
-  inv: function(x, mu, b) {
+  inv: function(p, mu, b) {
+    var x = p - 0.5;
     return mu - (b * laplaceSign(x) * Math.log(1 - (2 * Math.abs(x))));
   },
 

--- a/src/distribution.js
+++ b/src/distribution.js
@@ -1213,6 +1213,10 @@ jStat.extend(jStat.laplace, {
     }
   },
 
+  inv: function(x, mu, b) {
+    return mu - (b * laplaceSign(x) * Math.log(1 - (2 * Math.abs(x))));
+  },
+
   mean: function(mu/*, b*/) {
     return mu;
   },

--- a/test/distribution/laplace-test.js
+++ b/test/distribution/laplace-test.js
@@ -51,6 +51,15 @@ suite.addBatch({
             assert.epsilon(tol, cdf(1, 1, 0), 0);
             assert.epsilon(tol, cdf(1, 1, -2), 0);
         },
+        'check inv calculation': function(jStat) {
+            var inv = jStat.laplace.inv;
+            assert.epsilon(tol, inv(0.01, 0, 1.0), -3.91202);
+            assert.epsilon(tol, inv(0.05, 0, 1.0), -2.30258);
+
+            assert.epsilon(tol, inv(0.95, -1, 2.0), 3.60517);
+            assert.epsilon(tol, inv(0.99, -1, 3.0), 10.7360);
+
+        },
         'mean': function(jStat) {
             var mean = jStat.laplace.mean;
 


### PR DESCRIPTION
Dear all,

While creating an animation (<https://josephsalmon.github.io/HAX603X/Courses/notations.html#cas-des-variables-discr%C3%A8tes>), I realized that the `inv` (quantile) function was missing for the Laplace distribution.
The formula is given on Wikipedia <https://en.wikipedia.org/wiki/Laplace_distribution#Cumulative_distribution_function>, and is also the same function used for the sample function (since this is require for the inverse transform method) in the current code.

Hence, this PR solves this by adding
- the corresponding `inv` function itself
- the associated tests (for 4 different values of  `p,mu,b`).

I hope this helps and get merged.
Best,
Joseph